### PR TITLE
Make Java version configurable, fix warnings on tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-target/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
 commons-opensource-super-pom
 ============================
 
-Commons Super POM for Open Source projects
+Commons Super POM for Open Source projects.
+
+The Super POM contains build configuration that is common to many (sometimes all) modules.
+
+The motivation for its use is to single-source as much of the lightweight, often-used build configuration as possible.
+
+Usage
+-----
+
+Add the following to the top of your project's root or parent pom.xml:
+
+```xml
+<parent>
+    <groupId>com.bazaarvoice.commons</groupId>
+    <artifactId>bv-opensource-super-pom</artifactId>
+    <version>1.2</version>
+    <relativePath />
+</parent>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,9 @@
     </scm>
 
     <properties>
+        <!-- Child projects may override these settings. -->
+        <java.minimum.version>1.6</java.minimum.version>
+
         <!-- maven-driving properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -54,7 +57,7 @@
             </testResource>
         </testResources>
         <plugins>
-            <!-- enforce Maven and Java version -->
+            <!-- Enforce minimum Maven and Java versions. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -71,20 +74,20 @@
                                     <version>3.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>1.6</version>
+                                    <version>${java.minimum.version}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            <!-- use java 1.6 for all compilation -->
+            <!-- Require minimum of java 1.6 for all compilation (child projects may override via "java.minimum.version") -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.minimum.version}</source>
+                    <target>${java.minimum.version}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -114,22 +117,26 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.16</version>
+                    <version>2.15</version>
                     <configuration>
-                        <argLine>-Djava.awt.headless=true</argLine>
+                        <argLine>-Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
                         <excludes>
                             <!-- Exclude the Integration Tests; see also maven-failsafe-plugin configuration below -->
                             <exclude>test/integration/**</exclude>
                         </excludes>
-                        <systemProperties>
-                            <file.encoding>UTF-8</file.encoding> <!-- jvm should load resources assuming UTF-8 -->
-                        </systemProperties>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.4</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            </manifest>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -149,15 +156,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.16</version>
+                    <version>2.15</version>
                     <configuration>
-                        <argLine>-Djava.awt.headless=true</argLine>
+                        <argLine>-Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
                         <includes>
                             <include>test/integration/**</include>
                         </includes>
-                        <systemProperties>
-                            <file.encoding>UTF-8</file.encoding> <!-- jvm should load resources assuming UTF-8 -->
-                        </systemProperties>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Also, make it the default that module version info is written to jar manifests.  And back down maven surefire/failsafe plugins to work around JVM crashes observed w/local "mvn verify" on OS/X.
