### PR TITLE
Updating maven-release-plugin to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.4.2</version>
+                    <version>2.5.1</version>
                     <configuration>
                         <scmCommentPrefix>branch admin -</scmCommentPrefix>
                     </configuration>


### PR DESCRIPTION
There is a bad interaction between the old version of the maven-release-plugin and a new version of git.
https://jira.codehaus.org/browse/MRELEASE-812

Basically, the "prepare" stage would fail to push the updated poms, resulting in the release version still being a "SNAPSHOT." Version 2.5.1 of the maven-release-plugin remedies this.
