### PR TITLE
Update version of owasp dependency-check-maven plugin 1.3.1 -> 1.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>1.3.1</version>
+                    <version>1.4.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Comment in the pom says this plugin should be kept up to date, but it's a few versions behind.  Latest version of the plugin seems to work fine with jolt, but I didn't check other projects.