### PR TITLE
[AVI-5465] - remove test-results-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,11 +278,6 @@
                 <!-- Bazaarvoice-authored plugins. -->
                 <plugin>
                     <groupId>com.bazaarvoice.maven.plugins</groupId>
-                    <artifactId>test-results-plugin</artifactId>
-                    <version>1.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.bazaarvoice.maven.plugins</groupId>
                     <artifactId>solr-setup-plugin</artifactId>
                     <version>1.2</version>
                 </plugin>


### PR DESCRIPTION
_Similar PR against `commons-super-pom`: https://github.com/bazaarvoice/commons-super-pom/pull/22_
### JIRA Ticket

[AVI-5465](https://bits.bazaarvoice.com/jira/browse/AVI-5465)

### What Are We Doing Here?

Deprecating old, no longer needed maven `test-results-plugin`.

Source repo: https://github.com/bazaarvoice/maven-test-results-plugin

Before removing the plugin from `super-pom`, we removed its usages from everywhere else:

- https://github.com/search?q=org%3Abazaarvoice+test-results-plugin&type=Code
- [Inspector Gadget](https://ig.bazaarvoice.com/search?q=test-results-plugin&defs=&refs=&path=&hist=&project=customers-trunk&project=defaultui-4.7&project=defaultui-4.8&project=defaultui-4.9&project=defaultui-5.0&project=defaultui-5.1&project=defaultui-5.3&project=defaultui-5.6&project=metadata-trunk&project=monitor-trunk&project=ops-trunk&project=product-schema-trunk&project=prr-37.7&project=prr-customer-config&project=prr-trunk&project=techservices-trunk)

Functionality: creates `testng-results.html` page out of `testng-results.xml` for any found target/surefire-reports and target/failsafe-reports

Example: Here is `failsafe-reports` folder for PRR CIT. We have both [testng-results.xml](https://jenkins.nexus.bazaarvoice.com/view/DataPlatform/job/dataplatform/job/prr-release-jobs/job/product-cit/job/trunk/job/full-integration-suite-code-coverage-on-testcustomers/174/artifact/prr/quality/integration-suite/target/failsafe-reports/testng-results.xml), which is published by Jenkins plugin on a build level, and [testng-results.html](https://jenkins.nexus.bazaarvoice.com/view/DataPlatform/job/dataplatform/job/prr-release-jobs/job/product-cit/job/trunk/job/full-integration-suite-code-coverage-on-testcustomers/174/artifact/prr/quality/integration-suite/target/failsafe-reports/testng-results.html), which can be viewed directly

Reasons for deprecation:

- ATM the most commonly used CI tool is Jenkins. It provides functionality to publish .xml reports directly

- There are no consumers of the library left 

- Given the existing limit on number of Github repos, we're interested in archiving any unused one
